### PR TITLE
최은소 week6 정리

### DIFF
--- a/최은소/week 6/HorizontalPodAutoscaler.md
+++ b/최은소/week 6/HorizontalPodAutoscaler.md
@@ -1,0 +1,81 @@
+# Horizontal Pod Autoscaler (HPA)
+
+## 개요
+쿠버네티스에서 `HorizontalPodAutoscaler`는 워크로드 리소스(예: Deployment, StatefulSet 등)를 자동으로 업데이트하고, 수요에 맞게 파드 수를 수평적으로 스케일링하는 오브젝트이다.
+
+## 작동 방식
+- 주기적으로 메트릭(CPU/메모리 사용률, 커스텀 메트릭 등)을 수집하고, 원하는 레플리카 수를 계산
+- 대상 리소스의 `.spec.selector`로 파드 선택
+- 사용률(또는 원시 값)을 기반으로 현재 메트릭 / 원하는 메트릭 비율 계산
+- 허용 오차(`--horizontal-pod-autoscaler-tolerance`, 기본값 0.1) 내이면 스케일링 생략
+- 스케일다운 시 안정화 윈도우(`--horizontal-pod-autoscaler-downscale-stabilization`, 기본값 5분) 고려
+
+## 기본 공식
+```
+desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
+```
+
+## 주요 구성 요소
+- **메트릭 서버(metrics-server)**: `metrics.k8s.io` API 제공
+- **커스텀 메트릭 어댑터**: `custom.metrics.k8s.io` API
+- **외부 메트릭 어댑터**: `external.metrics.k8s.io` API
+
+## 지원 리소스 메트릭 예시
+```yaml
+type: Resource
+resource:
+  name: cpu
+  target:
+    type: Utilization
+    averageUtilization: 60
+```
+
+## 컨테이너 리소스 메트릭 예시
+```yaml
+type: ContainerResource
+containerResource:
+  name: cpu
+  container: application
+  target:
+    type: Utilization
+    averageUtilization: 60
+```
+
+## 스케일링 동작 구성 예시
+```yaml
+behavior:
+  scaleDown:
+    stabilizationWindowSeconds: 300
+    policies:
+    - type: Percent
+      value: 10
+      periodSeconds: 60
+    - type: Pods
+      value: 5
+      periodSeconds: 60
+    selectPolicy: Min
+```
+
+## 명령어 예시
+```bash
+kubectl autoscale deployment nginx --cpu-percent=50 --min=1 --max=10
+kubectl get hpa
+kubectl describe hpa <name>
+kubectl delete hpa <name>
+```
+
+## HPA와 Deployment 연동 시 주의사항
+- `spec.replicas`는 매니페스트에서 제거 권장
+- 그렇지 않으면 `kubectl apply`시 해당 값으로 다시 조정됨
+- 서버 사이드 적용 시 안전하게 오너십을 넘기는 방식 사용 가능:
+```bash
+kubectl apply -f nginx-deployment-replicas-only.yaml --server-side --field-manager=handover-to-hpa
+```
+
+## 추가 기능 요약
+- **복수 메트릭**: 가장 큰 스케일 제안 사용
+- **안정화 윈도우**: 갑작스러운 변화 방지
+- **스케일링 제한 정책**: `Pods`, `Percent` 유형으로 설정
+- **스케일 비활성화**: `selectPolicy: Disabled` 사용
+- **점검모드 비활성화**: replicas=0 설정 시 자동 중단됨
+

--- a/최은소/week 6/Namespace.md
+++ b/최은소/week 6/Namespace.md
@@ -1,0 +1,96 @@
+# Kubernetes 네임스페이스 (Namespace)
+
+쿠버네티스에서 **네임스페이스(Namespace)** 는 단일 클러스터 내에서 리소스를 격리하는 메커니즘을 제공한다.
+
+---
+
+## 1. 개요
+
+- 리소스의 이름은 네임스페이스 내에서 유일하면 충분하다.
+- **네임스페이스 기반 스코핑**은 네임스페이스 기반 오브젝트(예: Deployment, Service 등)에만 적용된다.
+- 클러스터 범위 오브젝트(예: Node, PersistentVolume 등)에는 적용되지 않는다.
+
+---
+
+## 2. 사용 시점
+
+- **필요한 경우만** 사용. 사용자 수가 적은 환경에서는 사용하지 않아도 된다.
+- 여러 팀/프로젝트가 있는 환경에서 유용하다.
+- 동일 네임스페이스 내 리소스 구분은 레이블을 사용.
+
+---
+
+## 3. 초기 네임스페이스
+
+| 이름              | 설명 |
+|------------------|------|
+| `default`        | 기본 네임스페이스. 네임스페이스 없이 생성되는 리소스의 위치. |
+| `kube-node-lease`| 노드 하트비트용 lease 객체 위치. |
+| `kube-public`    | 인증되지 않은 클라이언트도 읽기 가능. 전체 클러스터에서 공개 리소스용. |
+| `kube-system`    | 쿠버네티스 시스템 리소스 위치. |
+
+> 참고: `kube-` 접두사 네임스페이스는 시스템용으로 예약됨
+
+---
+
+## 4. 네임스페이스 관리
+
+### 생성/삭제
+
+- 자세한 내용은 "네임스페이스 관리자 가이드" 참고.
+
+### 조회
+
+```bash
+kubectl get namespace
+```
+
+### 네임스페이스 지정 요청
+
+```bash
+kubectl get pods --namespace=<namespace-name>
+kubectl run nginx --image=nginx --namespace=<namespace-name>
+```
+
+### 기본 네임스페이스 설정
+
+```bash
+kubectl config set-context --current --namespace=<namespace-name>
+kubectl config view --minify | grep namespace:
+```
+
+---
+
+## 5. 네임스페이스와 DNS
+
+- 서비스 DNS: `<svc-name>.<namespace>.svc.cluster.local`
+- 같은 네임스페이스 내에서는 `<svc-name>`으로도 접근 가능
+- 다른 네임스페이스 접근 시 FQDN 사용 필요
+
+> **주의**: 공개 TLD와 동일한 네임스페이스 이름은 DNS 충돌 가능
+
+---
+
+## 6. 네임스페이스에 속하지 않는 리소스
+
+- 예: `Node`, `PersistentVolume`, `Namespace` 자체 등
+- 조회 방법:
+
+```bash
+kubectl api-resources --namespaced=true   # 네임스페이스에 속하는 리소스
+kubectl api-resources --namespaced=false  # 네임스페이스에 속하지 않는 리소스
+```
+
+---
+
+## 7. 자동 레이블링 (Kubernetes 1.21+)
+
+- **기능 게이트**: `NamespaceDefaultLabelName` 활성화 시
+- 모든 네임스페이스에 `kubernetes.io/metadata.name` 레이블 자동 부여됨 (변경 불가)
+
+---
+
+## 참고
+
+- `default` 네임스페이스 대신 팀별 네임스페이스 권장
+- 공개 도메인과 충돌하지 않도록 네임스페이스 이름 주의


### PR DESCRIPTION
## HPA vs. AWS Auto Scaling

### 스케일링 대상
항목 | 쿠버네티스 HPA | AWS Auto Scaling
-- | -- | --
스케일 대상 | 파드 (Pod) | EC2 인스턴스 또는 ECS 태스크
리소스 단위 | 애플리케이션 레벨 | 인프라(서버) 레벨

### 작동 방식 및 트리거
항목 | 쿠버네티스 HPA | AWS Auto Scaling
-- | -- | --
메트릭 소스 | Pod CPU/메모리, 커스텀 메트릭 (metrics-server, Prometheus 등) | EC2 CPU, 네트워크, 사용자 지정 CloudWatch 지표
컨트롤러 위치 | kube-controller-manager 내부의 HPA 컨트롤러 | AWS Auto Scaling 그룹 또는 ECS 서비스
동작 주기 | 기본 15초 주기로 메트릭 체크 | CloudWatch 알람 기반 또는 Target Tracking (주기적 평가)
스케일 방식 | 파드 수 조정 (replica 수 변경) | 인스턴스 수 조정 (Launch Template 기준 인스턴스 생성/종료)

### 사용 목적
항목 | 쿠버네티스 HPA | AWS Auto Scaling
-- | -- | --
주 용도 | 애플리케이션 워크로드 자동 조정 | VM 인프라 자동 확장/축소
클라우드 종속성 | 클라우드 독립적 (On-prem도 가능) | AWS 전용 서비스
기타 스케일링 수단 | VPA(수직), CA(노드), KEDA(이벤트 기반)와 연계 가능 | ECS, Lambda 등 다른 서비스와 연계

쿠버네티스 HPA는 "앱 레벨" 자동화, AWS Auto Scaling은 "인프라 레벨" 자동화라고 이해하면 쉽다.